### PR TITLE
feat: ✨ #7 ピン止めの明示化

### DIFF
--- a/src/ui/header_view.rs
+++ b/src/ui/header_view.rs
@@ -21,11 +21,9 @@ pub fn header_view(ui: &mut Ui, app_state: &mut AppState) {
             app_state.current_month = (next_month_date.year(), next_month_date.month());
         }
 
-        // Pin to top button
-        let pin_button_text = if app_state.is_always_on_top { "📌" } else { "📍" };
-        if ui.button(pin_button_text).clicked() {
-            app_state.is_always_on_top = !app_state.is_always_on_top;
-        }
+        // Pin to top toggle switch
+        let toggle_text = if app_state.is_always_on_top { "📌 ON " } else { "📍 OFF " };
+        ui.toggle_value(&mut app_state.is_always_on_top, toggle_text);
 
         // Reset marked dates button
         if ui.button("Clear").clicked() {


### PR DESCRIPTION
##  概要

  このプルリクエストは、以下の2つの主要な機能追加と改善を行います。

   1. ピン止めを分かりやすくしました

##  変更点

   - 機能追加 (feat):
       - ui/header_view.rs: ヘッダーのピン止めをトグルしました #7 。

##  テスト方法

  1. ピン止め機能のテスト:
      1. アプリケーションを起動します (cargo run)。
      2. ピン止めボタンをオンオフして、Always on topがオンオフになるのを確認
      3. オン状態で色が変わり、オフ状態で色が戻るのを確認
      4. ダークテーマ、ライトテーマで動作確認

